### PR TITLE
Update set-output calls in GHA

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -99,7 +99,7 @@ function main {
         fi
     fi
 
-  echo ::set-output name=reviewed::${required_reviewers}
+  echo reviewed=${required_reviewers} >> $GITHUB_OUTPUT
 }
 
 main "${*}"


### PR DESCRIPTION
`set-output` is set to be deprecated in 2023. This change migrates calls of set-output to use the GITHUB_OUTPUT env file instead as per GH's recommendation.